### PR TITLE
Cleaning up gitignore and stuff

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-# set OpenWeatherMap API key here
-OWN_KEY = 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 
 # Environment variables should be ignored
 .env
+
+# Python virtual environment folders
+.venv
+venv/


### PR DESCRIPTION
Just a quick fix on the `.gitignore` and to remove `.env` from the repo, which shouldn't be checked into git (it's in `.gitignore` for good reason). Otherwise, pulling from remote will overwrite your local `.env` file you have.  As long as you have `.env` listed in your gitignore file, pushing to git via command line or Pycharm will ignore that file and exclude it from pushing to github. 

I do like the idea of, if the file doesn't exit, having the script create the file for you (perhaps for a first-time run), and even prompting for an Open Weather Map key, and storing it programmatically that way. This would automate setup a bit better. Perhaps this can be written in a separate `setup.py` file to separate setup code from main code.