### PR TITLE
Fix small output related bug

### DIFF
--- a/config.py
+++ b/config.py
@@ -36,15 +36,15 @@ def set_new_weather_key():
 
     # If the file exists and is not empty, append onto a new line
     if os.stat('./.env').st_size == 0:
-        print('.env is empty!')
         env_file = open('.env', 'w')
         env_file.write(f'OWM_KEY={weather_key}')
     else:
-        print('.env is not empty!')
         env_file = open('.env', 'a')
         env_file.write(f'\nOWM_KEY={weather_key}')
 
     env_file.close()
+
+    load_dotenv()
 
     if os.getenv('OWM_KEY'):
         print('Key has been set to environment!')


### PR DESCRIPTION
Small bug, nothing functionally broke, but terminal output displayed 'Something went wrong setting OWM key to the environment.' even when nothing did go wrong. Fixed by loading the env once more with `load_dotenv()`, which sort of rereads/refreshes the .env file.